### PR TITLE
同じメモリ領域への2回目のアクセス時にはページフォールトが発生しないことを確認するスクリプト追加

### DIFF
--- a/chapter05/demand-paging_twice.c
+++ b/chapter05/demand-paging_twice.c
@@ -1,0 +1,66 @@
+#include <unistd.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+
+#define BUFFER_SIZE	(100 * 1024 * 1024)
+#define NCYCLE		10
+#define PAGE_SIZE	4096
+
+int main(void)
+{
+	char *p;
+	time_t t;
+	char *s;
+
+	t = time(NULL);
+	s = ctime(&t);
+	printf("%.*s: before allocation, please press Enter key\n",
+	       (int)(strlen(s) - 1), s);
+	getchar();
+
+	p = malloc(BUFFER_SIZE);
+	if (p == NULL)
+		err(EXIT_FAILURE, "malloc() failed");
+
+	t = time(NULL);
+	s = ctime(&t);
+	printf("%.*s: allocated %dMB, please press Enter key\n",
+	       (int)(strlen(s) - 1), s, BUFFER_SIZE / (1024 * 1024));
+	getchar();
+
+	int i;
+	for (i = 0; i < BUFFER_SIZE; i += PAGE_SIZE) {
+		p[i] = 0;
+		int cycle = i / (BUFFER_SIZE / NCYCLE);
+		if (cycle != 0 && i % (BUFFER_SIZE / NCYCLE) == 0) {
+			t = time(NULL);
+			s = ctime(&t);
+			printf("%.*s: touched %dMB\n",
+			       (int) (strlen(s) - 1), s, i / (1024*1024));
+			sleep(1);
+		}
+	}
+
+	for (i = 0; i < BUFFER_SIZE; i += PAGE_SIZE) {
+		p[i] = 0;
+		int cycle = i / (BUFFER_SIZE / NCYCLE);
+		if (cycle != 0 && i % (BUFFER_SIZE / NCYCLE) == 0) {
+			t = time(NULL);
+			s = ctime(&t);
+			printf("%.*s: touched %dMB\n",
+			       (int) (strlen(s) - 1), s, i / (1024*1024));
+			sleep(1);
+		}
+	}
+
+	t = time(NULL);
+	s = ctime(&t);
+	printf("%.*s: touched %dMB, please press Enter key\n",
+	       (int) (strlen(s) - 1), s, BUFFER_SIZE / (1024 * 1024));
+	getchar();
+
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
第5章 デマンドページングの下記部分を試した。

```
なお、ここで例は示しませんが、このあと再び同じメモリ領域にアクセスしても、
2回目以降はページフォールトが発生しません。なぜなら一度ページにアクセスしたあとは、
ページに対応する物理メモリはすでに割り当て済みだからです。
興味のあるかたはソースコードを変更して試してみてください。

武内 覚. ［試して理解］Linuxのしくみ ～実験と図解で学ぶOSとハードウェアの基礎知識 (Japanese Edition)
 (Kindle の位置No.2008-2011). Kindle 版. 
```